### PR TITLE
fix bug of longer variables names breaking parsing of line

### DIFF
--- a/copyTemplate.html
+++ b/copyTemplate.html
@@ -43,8 +43,8 @@
     showCopyMessage()
   }
 
+<!-- creates invisible container of generated html, from which we copy into clipboard -->
   function getFormattedSelection(rawTemplateItems) {
-    console.log(rawTemplateItems)
     const container = document.createElement('div')
     // Hide element
     container.style.position = 'fixed'
@@ -55,13 +55,11 @@
       container.appendChild(createFormattedItem(rawTemplateItems[i]))
     }
 
-      console.log('created --> ', container)
-
     return container
   }
 
+<!-- creates html from metadata generated in getTemplates -->
   function createFormattedItem(rawData) {
-    console.log({ rawData })
     const itemType = rawData.type
     switch (itemType) {
       case 'break':

--- a/createUI.html
+++ b/createUI.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <script>
+  // get the locations of the headers from the google doc
   google.script.run.withSuccessHandler(loadForm).getTemplateHeaders()
   let headers = []
   let headerIndexes = []

--- a/getTemplates.js
+++ b/getTemplates.js
@@ -1,19 +1,4 @@
-/**
- * To do: 
- * [x] : account for lines that are only spaces, but not technically '' 
- * [x] : how will you know when two inline list elements are the same line? 
- * [x] : button should not be pressable until option is selected 
- * [x] : "copied!" indicator 
- * [x] : variables 
- * [x] : do variables pop up after selection is made? should they pop up after loading indicator 
- * [ ] : pressing copy should recompute changes to header positions
- * [ ] : reset button 
- * [x] : split javascript up into pre-copy, post copy 
- * [x] : styling 
- */
-
 let inputVariables = {}
-
 
 const getTemplateHeaders = () => {
   const headers = []
@@ -84,8 +69,9 @@ const constructListFromIndex = listIndex => {
 }
 
 
+// translates line data from google docs into format the html generator can process
 const constructItemsFromLine = line => {
-  const lineText = withTemplateVars(line.getText())
+  const lineText = line.getText()
   const metadataForLine = []
   let currentText = '';
   let currentLink = '';
@@ -118,6 +104,8 @@ const constructItemsFromLine = line => {
 
     currentText += lineText[i]
   }
+  // replace form variables with corresponding values 
+  currentText = withTemplateVars(currentText)
   // cleanup whatever is left over
   if (currentLink) {
     metadataForLine.push(linkMetaData(currentText, currentLink))
@@ -129,7 +117,7 @@ const constructItemsFromLine = line => {
 }
 
 const withTemplateVars = text => {
-  return text.replace(/<contact>|<company>/gi, inputVariables[matched])
+  return text.replace(/<contact>|<company>/gi, matched => inputVariables[matched])
 }
 
 


### PR DESCRIPTION
Fixes bug where longer variable names were breaking the parsing of a line in the google doc. Also cleans up some logs, adds comments. 